### PR TITLE
 Remove support for python-3.9 and polars < 1.2.0 

### DIFF
--- a/docs/_renderer.py
+++ b/docs/_renderer.py
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 import html
-import os
 import re
 from importlib.resources import files
 from pathlib import Path
-from typing import Literal, Optional, TypedDict, Union
+from typing import Optional, Union
 
 import quartodoc.ast as qast
 from griffe import (
@@ -26,21 +25,12 @@ from quartodoc.pandoc.blocks import DefinitionList
 from quartodoc.renderers.base import convert_rst_link_to_md, sanitize
 from quartodoc.renderers.md_renderer import ParamRow
 
-# from quartodoc.ast import preview
 
-SHINY_PATH = Path(files("pelage").joinpath())
-
-
-# This is the same as the FileContentJson type in TypeScript.
-class FileContentJson(TypedDict):
-    name: str
-    content: str
-    type: Literal["text", "binary"]
+SHINY_PATH = Path(str(files("pelage").joinpath()))
 
 
 class Renderer(MdRenderer):
     style = "shiny"
-    express_api = os.environ.get("SHINY_MODE", "core") == "express"
 
     @dispatch
     def render(self, el: qast.DocstringSectionSeeAlso):
@@ -62,26 +52,6 @@ class Renderer(MdRenderer):
 
         converted = convert_rst_link_to_md(rendered)
 
-        # If we're rendering the API reference for Express, try our best to
-        # keep you in the Express site. For example, something like shiny.ui.input_text()
-        # simply gets re-exported as shiny.express.ui.input_text(), but it's docstrings
-        # will link to shiny.ui, not shiny.express.ui. This fixes that.
-        if self.express_api:
-            converted = converted.replace("shiny.ui.", "shiny.express.ui.")
-            # If this el happens to point to itself, it's probably intentionally
-            # pointing to Core (i.e., express context managers mention that they
-            # wrap Core functions), so don't change that.
-            # TODO: we want to be more aggressive about context managers always
-            # pointing to the Core docs?
-            if f"shiny.express.ui.{el.name}" in converted:
-                print(f"Changing Express link to Core for: {el.name}")
-                converted = converted.replace(
-                    f"shiny.express.ui.{el.name}", f"shiny.ui.{el.name}"
-                )
-            converted = converted.replace("shiny.render.", "shiny.express.render.")
-
-        check_if_missing_expected_example(el, converted)
-
         assert_no_sphinx_comments(el, converted)
 
         return converted
@@ -98,17 +68,6 @@ class Renderer(MdRenderer):
     @dispatch
     def render_annotation(self, el: str):
         return sanitize(el)
-
-    # TODO-future; Can be removed once we use quartodoc 0.3.5
-    # Related: https://github.com/machow/quartodoc/pull/205
-    @dispatch
-    def render(self, el: DocstringAttribute) -> ParamRow:
-        row = ParamRow(
-            el.name,
-            el.description or "",
-            annotation=self.render_annotation(el.annotation),
-        )
-        return row
 
     @dispatch
     def render_annotation(self, el: None):
@@ -253,56 +212,7 @@ def prefix_bare_functions_with_func(s: str) -> str:
     return re.sub(pattern, replacement, s)
 
 
-def check_if_missing_expected_example(el, converted):
-    if re.search(r"(^|\n)#{2,6} Examples", converted):
-        # Manually added examples are fine
-        return
-
-    if not el.canonical_path.startswith("shiny"):
-        # Only check Shiny objects for examples
-        return
-
-    def is_no_ex_decorator(x):
-        # With griffe<0.42.0, it kept parentheses on decorators, but as of 0.42.0, it
-        # removes them. At some point in the future we can just use the no-parens case.
-        if x == "no_example()" or x == "no_example":
-            return True
-
-        no_ex_decorators = [
-            f'no_example("{os.environ.get("SHINY_MODE", "core")}")',
-            f"no_example('{os.environ.get('SHINY_MODE', 'core')}')",
-        ]
-
-        return x in no_ex_decorators
-
-    if hasattr(el, "decorators") and any(
-        [is_no_ex_decorator(d.value.canonical_name) for d in el.decorators]
-    ):
-        # When an example is intentionally omitted, we mark the fn with `@no_example`
-        return
-
-    if not el.is_function:
-        # Don't throw for things that can't be decorated
-        return
-
-    if not el.is_exported:
-        # Don't require examples on "implicitly exported" functions
-        # In practice, this covers methods of exported classes (class still needs ex)
-        return
-
-    no_req_examples = ["shiny.experimental"]
-    if any([el.target_path.startswith(mod) for mod in no_req_examples]):
-        return
-
-    raise RuntimeError(
-        f"{el.name} needs an example, use `@add_example()` or manually add `Examples` section:\n"
-        + (f"> file     : {el.filepath}\n" if hasattr(el, "filepath") else "")
-        + (f"> target   : {el.target_path}\n" if hasattr(el, "target_path") else "")
-        + (f"> canonical: {el.canonical_path}" if hasattr(el, "canonical_path") else "")
-    )
-
-
-def assert_no_sphinx_comments(el, converted: str) -> None:
+def assert_no_sphinx_comments(el: Alias, converted: str) -> None:
     """
     Sphinx allows `..`-prefixed comments in docstrings, which are not valid markdown.
     We don't allow Sphinx comments or directives, sorry!

--- a/docs/reference/at_least_one.qmd
+++ b/docs/reference/at_least_one.qmd
@@ -12,12 +12,12 @@ Ensure that there is at least one not null value in the designated columns.
 
 :   Polars DataFrame or LazyFrame containing data to check.
 
-<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   Columns to consider to check the presence of at least one value.
     By default, all columns are checked.
 
-<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   When specified perform the check per group instead of the whole column,
     by default None

--- a/docs/reference/has_columns.qmd
+++ b/docs/reference/has_columns.qmd
@@ -12,7 +12,7 @@ Check if a DataFrame has the specified
 
 :   The polars DataFrame or LazyFrame to test.
 
-<code><span class="parameter-name">names</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Union](`typing.Union`)\[[str](`str`), [List](`List`)\[[str](`str`)\]\]</span></code>
+<code><span class="parameter-name">names</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Union](`Union`)\[[str](`str`), [List](`List`)\[[str](`str`)\]\]</span></code>
 
 :   The names of the columns to check.
 

--- a/docs/reference/has_mandatory_values.qmd
+++ b/docs/reference/has_mandatory_values.qmd
@@ -17,7 +17,7 @@ Ensure that all specified values are present in their respective column.
 :   A dictionnary where the keys are the columns names and the values are lists that
     contains all the required values for a given column.
 
-<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   When specified perform the check per group instead of the whole column,
     by default None

--- a/docs/reference/has_no_infs.qmd
+++ b/docs/reference/has_no_infs.qmd
@@ -12,7 +12,7 @@ Check if a DataFrame has any infinite (inf) values.
 
 :   The input DataFrame to check for null values.
 
-<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   Columns to consider for null value check. By default, all columns are checked.
 

--- a/docs/reference/has_no_nulls.qmd
+++ b/docs/reference/has_no_nulls.qmd
@@ -12,7 +12,7 @@ Check if a DataFrame has any null (missing) values.
 
 :   The input DataFrame to check for null values.
 
-<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   Columns to consider for null value check. By default, all columns are checked.
 

--- a/docs/reference/has_shape.qmd
+++ b/docs/reference/has_shape.qmd
@@ -23,7 +23,7 @@ When used with the group_by option, this can be used to get the row count per gr
     Ex: `(5, None)` will ensure that the dataframe has 5 rows regardless of the
     number of columns.
 
-<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   When specified compares the number of lines per group with the expected value,
     by default None

--- a/docs/reference/is_monotonic.qmd
+++ b/docs/reference/is_monotonic.qmd
@@ -32,7 +32,7 @@ Verify that values in a column are consecutively increasing or decreasing.
 :   The series must be stricly increasing or decreasing, no consecutive equal values
     are allowed, by default True
 
-<code><span class="parameter-name">interval</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[Union](`typing.Union`)\[[int](`int`), [float](`float`), [str](`str`), [pl](`polars`).[Duration](`polars.Duration`)\]\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">interval</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[Union](`Union`)\[[int](`int`), [float](`float`), [str](`str`), [pl](`polars`).[Duration](`polars.Duration`)\]\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   For time-based column, the interval can be specified as a string as in the
     function `dt.offset_by` or `pl.DataFrame().rolling`. It can also be specified
@@ -59,7 +59,7 @@ Verify that values in a column are consecutively increasing or decreasing.
 
     By default None
 
-<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   When specified, the monotonic characteristics and intervals are estimated for
     each group independently.

--- a/docs/reference/maintains_relationships.qmd
+++ b/docs/reference/maintains_relationships.qmd
@@ -13,7 +13,7 @@ Function to help ensuring that set of values in selected column remains  the
 
 :   The polars DataFrame or LazyFrame to test.
 
-<code><span class="parameter-name">other_df</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Union](`typing.Union`)\[[pl](`polars`).[DataFrame](`polars.DataFrame`), [pl](`polars`).[LazyFrame](`polars.LazyFrame`)\]</span></code>
+<code><span class="parameter-name">other_df</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Union](`Union`)\[[pl](`polars`).[DataFrame](`polars.DataFrame`), [pl](`polars`).[LazyFrame](`polars.LazyFrame`)\]</span></code>
 
 :   Distant dataframe usually the one before transformation
 

--- a/docs/reference/not_constant.qmd
+++ b/docs/reference/not_constant.qmd
@@ -12,11 +12,11 @@ Check if a DataFrame has constant columns.
 
 :   The input DataFrame to check for null values.
 
-<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   Columns to consider for null value check. By default, all columns are checked.
 
-<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsOverClauseInput](`PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsOverClauseInput](`PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   When specified perform the check per group instead of the whole column,
     by default None

--- a/docs/reference/not_null_proportion.qmd
+++ b/docs/reference/not_null_proportion.qmd
@@ -30,7 +30,7 @@ a specified range [at_least, at_most] where at_most is an optional argument
     When specifying a single float, the higher bound of the range will automatically
     be set to 1.0, i.e. (given_float, 1.0)
 
-<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   When specified perform the check per group instead of the whole column,
     by default None

--- a/docs/reference/unique.qmd
+++ b/docs/reference/unique.qmd
@@ -15,11 +15,11 @@ duplicated values. For a row oriented check see `unique_combination_of_columns`
 
 :   The input DataFrame to check for unique values.
 
-<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   Columns to consider for uniqueness check. By default, all columns are checked.
 
-<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">group_by</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsOverClauseInput](`pelage.types.PolarsOverClauseInput`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   Use this option to ensure uniqueness with data segmented by group.
     by default None

--- a/docs/reference/unique_combination_of_columns.qmd
+++ b/docs/reference/unique_combination_of_columns.qmd
@@ -15,7 +15,7 @@ i.e. this is a row oriented check.
 
 :   The polars DataFrame or LazyFrame to test.
 
-<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`typing.Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
+<code><span class="parameter-name">columns</span><span class="parameter-annotation-sep">:</span> <span class="parameter-annotation">[Optional](`Optional`)\[[PolarsColumnType](`pelage.types.PolarsColumnType`)\]</span> <span class="parameter-default-sep">=</span> <span class="parameter-default">None</span></code>
 
 :   Columns to consider for row unicity. By default, all columns are checked.
 

--- a/pelage/checks/at_least_one.py
+++ b/pelage/checks/at_least_one.py
@@ -6,7 +6,7 @@ from pelage.types import (
     PolarsLazyOrDataFrame,
     PolarsOverClauseInput,
 )
-from pelage.utils import _has_sufficient_polars_version, _sanitize_column_inputs
+from pelage.utils import _sanitize_column_inputs
 
 
 def at_least_one(
@@ -95,32 +95,18 @@ def at_least_one(
     selected_columns = _sanitize_column_inputs(columns)
 
     if group_by is not None:
-        if _has_sufficient_polars_version("1.0.0"):
-            only_nulls_per_group = (
-                data.lazy()
-                .group_by(group_by)
-                .agg(selected_columns.null_count() < pl.len())
-                .unpivot(
-                    index=group_by,  # type: ignore
-                    variable_name="columns",
-                    value_name="at_least_one",
-                )
-                .filter(pl.col("at_least_one").not_())
-                .collect()
+        only_nulls_per_group = (
+            data.lazy()
+            .group_by(group_by)
+            .agg(selected_columns.null_count() < pl.len())
+            .unpivot(
+                index=group_by,  # type: ignore
+                variable_name="columns",
+                value_name="at_least_one",
             )
-        else:
-            only_nulls_per_group = (
-                data.lazy()
-                .group_by(group_by)
-                .agg(selected_columns.null_count() < pl.len())
-                .melt(
-                    id_vars=group_by,  # type: ignore
-                    variable_name="columns",
-                    value_name="at_least_one",
-                )
-                .filter(pl.col("at_least_one").not_())
-                .collect()
-            )
+            .filter(pl.col("at_least_one").not_())
+            .collect()
+        )
 
         if len(only_nulls_per_group) > 0:
             raise PolarsAssertError(

--- a/pelage/checks/at_least_one.py
+++ b/pelage/checks/at_least_one.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -13,8 +11,8 @@ from pelage.utils import _has_sufficient_polars_version, _sanitize_column_inputs
 
 def at_least_one(
     data: PolarsLazyOrDataFrame,
-    columns: Optional[PolarsColumnType] = None,
-    group_by: Optional[PolarsOverClauseInput] = None,
+    columns: PolarsColumnType | None = None,
+    group_by: PolarsOverClauseInput | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Ensure that there is at least one not null value in the designated columns.
 

--- a/pelage/checks/has_columns.py
+++ b/pelage/checks/has_columns.py
@@ -1,14 +1,6 @@
 import polars as pl
 
 from pelage.types import PolarsAssertError, PolarsLazyOrDataFrame
-from pelage.utils import _has_sufficient_polars_version
-
-
-def _get_lazyframe_columns(data: pl.LazyFrame) -> set[str]:
-    if _has_sufficient_polars_version("1.0.0"):
-        return set(data.collect_schema().names())
-    else:
-        return set(data.columns)
 
 
 def has_columns(
@@ -68,7 +60,7 @@ def has_columns(
         # Because set(str) explodes the string
         names = [names]
     column_names_set = (
-        _get_lazyframe_columns(data)
+        set(data.collect_schema().names())
         if isinstance(data, pl.LazyFrame)
         else set(data.columns)
     )

--- a/pelage/checks/has_columns.py
+++ b/pelage/checks/has_columns.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 
 from pelage.types import PolarsAssertError, PolarsLazyOrDataFrame
@@ -14,7 +12,7 @@ def _get_lazyframe_columns(data: pl.LazyFrame) -> set[str]:
 
 
 def has_columns(
-    data: PolarsLazyOrDataFrame, names: Union[str, list[str]]
+    data: PolarsLazyOrDataFrame, names: str | list[str]
 ) -> PolarsLazyOrDataFrame:
     """Check if a DataFrame has the specified
 

--- a/pelage/checks/has_dtypes.py
+++ b/pelage/checks/has_dtypes.py
@@ -6,16 +6,13 @@ from pelage.types import (
     PolarsDataType,
     PolarsLazyOrDataFrame,
 )
-from pelage.utils import _has_sufficient_polars_version
 
 
 def _get_frame_schema(data: PolarsLazyOrDataFrame):
     if isinstance(data, pl.DataFrame):
         return data.schema
-    if _has_sufficient_polars_version("1.0.0"):
-        return data.collect_schema()
 
-    return data.schema
+    return data.collect_schema()
 
 
 def has_dtypes(

--- a/pelage/checks/has_mandatory_values.py
+++ b/pelage/checks/has_mandatory_values.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -39,7 +37,7 @@ def compare_sets_per_column(
 def has_mandatory_values(
     data: PolarsLazyOrDataFrame,
     items: dict[str, list],
-    group_by: Optional[PolarsOverClauseInput] = None,
+    group_by: PolarsOverClauseInput | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Ensure that all specified values are present in their respective column.
 

--- a/pelage/checks/has_no_infs.py
+++ b/pelage/checks/has_no_infs.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -12,7 +10,7 @@ from pelage.utils import _sanitize_column_inputs
 
 def has_no_infs(
     data: PolarsLazyOrDataFrame,
-    columns: Optional[PolarsColumnType] = None,
+    columns: PolarsColumnType | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Check if a DataFrame has any infinite (inf) values.
 

--- a/pelage/checks/has_no_nulls.py
+++ b/pelage/checks/has_no_nulls.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -15,7 +13,7 @@ from pelage.utils import (
 
 def has_no_nulls(
     data: PolarsLazyOrDataFrame,
-    columns: Optional[PolarsColumnType] = None,
+    columns: PolarsColumnType | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Check if a DataFrame has any null (missing) values.
 

--- a/pelage/checks/has_no_nulls.py
+++ b/pelage/checks/has_no_nulls.py
@@ -6,7 +6,6 @@ from pelage.types import (
     PolarsLazyOrDataFrame,
 )
 from pelage.utils import (
-    _has_sufficient_polars_version,
     _sanitize_column_inputs,
 )
 
@@ -65,21 +64,11 @@ def has_no_nulls(
     """
     selected_columns = _sanitize_column_inputs(columns)
     null_count = (
-        (
-            data.lazy()
-            .select(selected_columns.null_count())
-            .unpivot(variable_name="column", value_name="null_count")
-            .filter(pl.col("null_count") > 0)
-            .collect()
-        )
-        if _has_sufficient_polars_version("1.1.0")
-        else (
-            data.lazy()
-            .select(selected_columns.null_count())
-            .melt(variable_name="column", value_name="null_count")
-            .filter(pl.col("null_count") > 0)
-            .collect()
-        )
+        data.lazy()
+        .select(selected_columns.null_count())
+        .unpivot(variable_name="column", value_name="null_count")
+        .filter(pl.col("null_count") > 0)
+        .collect()
     )
 
     if not null_count.is_empty():

--- a/pelage/checks/has_shape.py
+++ b/pelage/checks/has_shape.py
@@ -6,7 +6,6 @@ from pelage.types import (
     PolarsLazyOrDataFrame,
     PolarsOverClauseInput,
 )
-from pelage.utils import _has_sufficient_polars_version
 
 
 def has_shape(
@@ -138,13 +137,7 @@ def _get_frame_shape(data: PolarsLazyOrDataFrame) -> tuple[int, int]:
     if isinstance(data, pl.DataFrame):
         return data.shape
 
-    if _has_sufficient_polars_version("1.0.0"):
-        return (
-            data.select(pl.len()).collect().item(),
-            len(data.collect_schema()),
-        )
-    else:
-        return (
-            data.select(pl.len()).collect().item(),
-            len(data.columns),
-        )
+    return (
+        data.select(pl.len()).collect().item(),
+        len(data.collect_schema()),
+    )

--- a/pelage/checks/has_shape.py
+++ b/pelage/checks/has_shape.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -14,7 +12,7 @@ from pelage.utils import _has_sufficient_polars_version
 def has_shape(
     data: PolarsLazyOrDataFrame,
     shape: tuple[IntOrNone, IntOrNone],
-    group_by: Optional[PolarsOverClauseInput] = None,
+    group_by: PolarsOverClauseInput | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Check if a DataFrame has the specified shape.
 

--- a/pelage/checks/is_monotonic.py
+++ b/pelage/checks/is_monotonic.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import polars as pl
 
 from pelage.types import (
@@ -14,8 +12,8 @@ def is_monotonic(
     column: str,
     decreasing: bool = False,
     strict: bool = True,
-    interval: Optional[Union[int, float, str]] = None,
-    group_by: Optional[PolarsOverClauseInput] = None,
+    interval: int | float | str | None = None,
+    group_by: PolarsOverClauseInput | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Verify that values in a column are consecutively increasing or decreasing.
 

--- a/pelage/checks/maintains_relationships.py
+++ b/pelage/checks/maintains_relationships.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 
 from pelage.types import PolarsAssertError, PolarsLazyOrDataFrame
@@ -7,8 +5,8 @@ from pelage.types import PolarsAssertError, PolarsLazyOrDataFrame
 
 def maintains_relationships(
     data: PolarsLazyOrDataFrame,
-    other_df: Union[pl.DataFrame, pl.LazyFrame],
-    column: Union[str, list[str]],
+    other_df: pl.DataFrame | pl.LazyFrame,
+    column: str | list[str],
 ) -> PolarsLazyOrDataFrame:
     """Function to help ensuring that set of values in selected column remains  the
         same in both DataFrames. This helps to maintain referential integrity.

--- a/pelage/checks/mutually_exclusive_ranges.py
+++ b/pelage/checks/mutually_exclusive_ranges.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -14,7 +12,7 @@ def mutually_exclusive_ranges(
     data: PolarsLazyOrDataFrame,
     low_bound: str,
     high_bound: str,
-    group_by: Optional[PolarsOverClauseInput] = None,
+    group_by: PolarsOverClauseInput | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Ensure that the specified columns contains no overlapping intervals.
 

--- a/pelage/checks/not_constant.py
+++ b/pelage/checks/not_constant.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import polars as pl
 
 from pelage.types import (
@@ -15,8 +13,8 @@ from pelage.utils import (
 
 def not_constant(
     data: PolarsLazyOrDataFrame,
-    columns: Optional[PolarsColumnType] = None,
-    group_by: Optional[Union[str, list[str]]] = None,
+    columns: PolarsColumnType | None = None,
+    group_by: str | list[str] | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Check if a DataFrame has constant columns.
 

--- a/pelage/checks/not_constant.py
+++ b/pelage/checks/not_constant.py
@@ -6,7 +6,6 @@ from pelage.types import (
     PolarsLazyOrDataFrame,
 )
 from pelage.utils import (
-    _has_sufficient_polars_version,
     _sanitize_column_inputs,
 )
 
@@ -107,43 +106,23 @@ def not_constant(
     selected_cols = _sanitize_column_inputs(columns)
 
     if group_by is None:
-        if _has_sufficient_polars_version("1.0.0"):
-            constant_columns = (
-                data.lazy()
-                .select(selected_cols.n_unique())
-                .unpivot(variable_name="column", value_name="n_distinct")
-                .filter(pl.col("n_distinct") == 1)
-                .collect()
-            )
-        else:
-            constant_columns = (
-                data.lazy()
-                .select(selected_cols.n_unique())
-                .melt(variable_name="column", value_name="n_distinct")
-                .filter(pl.col("n_distinct") == 1)
-                .collect()
-            )
+        constant_columns = (
+            data.lazy()
+            .select(selected_cols.n_unique())
+            .unpivot(variable_name="column", value_name="n_distinct")
+            .filter(pl.col("n_distinct") == 1)
+            .collect()
+        )
+
     else:
-        if _has_sufficient_polars_version("1.0.0"):
-            constant_columns = (
-                data.lazy()
-                .group_by(group_by)
-                .agg(selected_cols.n_unique())
-                .unpivot(
-                    index=group_by, variable_name="column", value_name="n_distinct"
-                )
-                .filter(pl.col("n_distinct") == 1)
-                .collect()
-            )
-        else:
-            constant_columns = (
-                data.lazy()
-                .group_by(group_by)
-                .agg(selected_cols.n_unique())
-                .melt(id_vars=group_by, variable_name="column", value_name="n_distinct")
-                .filter(pl.col("n_distinct") == 1)
-                .collect()
-            )
+        constant_columns = (
+            data.lazy()
+            .group_by(group_by)
+            .agg(selected_cols.n_unique())
+            .unpivot(index=group_by, variable_name="column", value_name="n_distinct")
+            .filter(pl.col("n_distinct") == 1)
+            .collect()
+        )
 
     if not constant_columns.is_empty():
         group_message = " within a given group" if group_by is not None else ""

--- a/pelage/checks/not_null_proportion.py
+++ b/pelage/checks/not_null_proportion.py
@@ -7,7 +7,6 @@ from pelage.types import (
 )
 from pelage.utils import (
     _format_ranges_by_columns,
-    _has_sufficient_polars_version,
 )
 
 
@@ -132,32 +131,18 @@ def not_null_proportion(
     else:
         formatted_data = data
 
-    if _has_sufficient_polars_version("1.0.0"):
-        null_proportions = (
-            formatted_data.lazy()
-            .group_by(group_by)
-            .agg(pl.all().null_count() / pl.len())
-            .unpivot(
-                index=group_by,  # type: ignore
-                variable_name="column",
-                value_name="null_proportion",
-            )
-            .with_columns(not_null_fraction=1 - pl.col("null_proportion"))
-            .collect()
+    null_proportions = (
+        formatted_data.lazy()
+        .group_by(group_by)
+        .agg(pl.all().null_count() / pl.len())
+        .unpivot(
+            index=group_by,  # type: ignore
+            variable_name="column",
+            value_name="null_proportion",
         )
-    else:
-        null_proportions = (
-            formatted_data.lazy()
-            .group_by(group_by)
-            .agg(pl.all().null_count() / pl.len())
-            .melt(
-                id_vars=group_by,  # type: ignore
-                variable_name="column",
-                value_name="null_proportion",
-            )
-            .with_columns(not_null_fraction=1 - pl.col("null_proportion"))
-            .collect()
-        )
+        .with_columns(not_null_fraction=1 - pl.col("null_proportion"))
+        .collect()
+    )
 
     if "constant__" in null_proportions.columns:
         null_proportions = null_proportions.drop("constant__")

--- a/pelage/checks/not_null_proportion.py
+++ b/pelage/checks/not_null_proportion.py
@@ -1,5 +1,3 @@
-from typing import Optional, Union
-
 import polars as pl
 
 from pelage.types import (
@@ -15,8 +13,8 @@ from pelage.utils import (
 
 def not_null_proportion(
     data: PolarsLazyOrDataFrame,
-    items: dict[str, Union[float, tuple[float, float]]],
-    group_by: Optional[PolarsOverClauseInput] = None,
+    items: dict[str, float | tuple[float, float]],
+    group_by: PolarsOverClauseInput | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Checks that the proportion of non-null values in a column is within a
     a specified range [at_least, at_most] where at_most is an optional argument

--- a/pelage/checks/unique.py
+++ b/pelage/checks/unique.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -13,8 +11,8 @@ from pelage.utils import _sanitize_column_inputs
 
 def unique(
     data: PolarsLazyOrDataFrame,
-    columns: Optional[PolarsColumnType] = None,
-    group_by: Optional[PolarsOverClauseInput] = None,
+    columns: PolarsColumnType | None = None,
+    group_by: PolarsOverClauseInput | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Check if there are no duplicated values in each one of the selected columns.
 

--- a/pelage/checks/unique_combination_of_columns.py
+++ b/pelage/checks/unique_combination_of_columns.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import polars as pl
 
 from pelage.types import (
@@ -14,7 +12,7 @@ from pelage.utils import (
 
 def unique_combination_of_columns(
     data: PolarsLazyOrDataFrame,
-    columns: Optional[PolarsColumnType] = None,
+    columns: PolarsColumnType | None = None,
 ) -> PolarsLazyOrDataFrame:
     """Ensure that the selected column have a unique combination per row.
 

--- a/pelage/types.py
+++ b/pelage/types.py
@@ -1,30 +1,26 @@
 """Module containing the type definitions for pelage."""
 
 from collections.abc import Iterable
-from typing import TypeVar, Union
+from typing import TypeVar
 
 import polars as pl
-
-try:
-    from polars._typing import ClosedInterval, IntoExpr, PolarsDataType
-
-except ImportError:
-    from polars.type_aliases import ClosedInterval, IntoExpr, PolarsDataType
+from polars._typing import ClosedInterval, IntoExpr, PolarsDataType
 
 # Use typevar to make sure that the input and return types are the same
 PolarsLazyOrDataFrame = TypeVar("PolarsLazyOrDataFrame", pl.DataFrame, pl.LazyFrame)
 
-PolarsColumnBounds = Union[
-    tuple[IntoExpr, IntoExpr], tuple[IntoExpr, IntoExpr, ClosedInterval]
-]
+PolarsColumnBounds = (
+    tuple[IntoExpr, IntoExpr] | tuple[IntoExpr, IntoExpr, ClosedInterval]
+)
 
-PolarsColumnType = Union[
-    str, Iterable[str], PolarsDataType, Iterable[PolarsDataType], pl.Expr
-]
 
-IntOrNone = Union[int, None]
+PolarsColumnType = (
+    str | Iterable[str] | PolarsDataType | Iterable[PolarsDataType] | pl.Expr
+)
 
-PolarsOverClauseInput = Union[IntoExpr, Iterable[IntoExpr]]
+IntOrNone = int | None
+
+PolarsOverClauseInput = IntoExpr | Iterable[IntoExpr]
 
 
 class PolarsAssertError(Exception):

--- a/pelage/utils.py
+++ b/pelage/utils.py
@@ -1,7 +1,5 @@
 """Utility functions for pelage."""
 
-from typing import Optional, Union
-
 import polars as pl
 
 from pelage.types import PolarsColumnType
@@ -29,7 +27,7 @@ def _has_sufficient_polars_version(version_number: str = "0.20.0") -> bool:
 
 
 def _sanitize_column_inputs(
-    columns: Optional[PolarsColumnType] = None,
+    columns: PolarsColumnType | None = None,
 ) -> pl.Expr:
     """Ensure that input can be converted to a `pl.col()` expression"""
     if columns is None:
@@ -41,7 +39,7 @@ def _sanitize_column_inputs(
 
 
 def _format_ranges_by_columns(
-    items: dict[str, Union[float, tuple[float, float]]],
+    items: dict[str, float | tuple[float, float]],
 ) -> pl.DataFrame:
     ranges = {k: (v if isinstance(v, tuple) else (v, 1)) for k, v in items.items()}
     pl_ranges = pl.DataFrame(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "coverage>=7.4.3",
     "ipykernel>=6.29.3",
     "tox-uv>=1.13.1",
+    "griffe==1.15.0",
 ]
 doc = ["quartodoc>=0.7.0; python_version >= '3.10'"]
 extras = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,10 @@ authors = [
 ]
 license = { text = "MIT" }
 
-requires-python = ">=3.9"
-dependencies = ["polars>=0.20"]
+requires-python = ">=3.10"
+dependencies = [
+    "polars>=1.2.0",
+]
 
 [project.urls]
 homepage = "https://alixtc.github.io/pelage"

--- a/tests/checks/test_accepted_values.py
+++ b/tests/checks/test_accepted_values.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -14,7 +12,7 @@ import pelage as plg
         pl.LazyFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}),
     ],
 )
-def test_accepted_values(given_df: Union[pl.DataFrame, pl.LazyFrame]):
+def test_accepted_values(given_df: pl.DataFrame | pl.LazyFrame):
     items = {"a": [1, 2, 3], "b": ["a", "b", "c"]}
     when = given_df.pipe(plg.accepted_values, items)
     testing.assert_frame_equal(given_df, when)
@@ -35,7 +33,7 @@ def test_accepted_values_should_accept_pl_expr():
     ],
 )
 def test_accepted_values_should_error_on_out_of_range_values(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     items = {"a": [1, 2], "b": ["a", "b", "c"]}
 

--- a/tests/checks/test_has_mandatory_values.py
+++ b/tests/checks/test_has_mandatory_values.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -14,7 +12,7 @@ import pelage as plg
         pl.LazyFrame({"a": [1, 2]}),
     ],
 )
-def test_has_mandatory_values(given_df: Union[pl.DataFrame, pl.LazyFrame]):
+def test_has_mandatory_values(given_df: pl.DataFrame | pl.LazyFrame):
     when = given_df.pipe(plg.has_mandatory_values, {"a": [1, 2]})
     testing.assert_frame_equal(given_df, when)
 
@@ -27,7 +25,7 @@ def test_has_mandatory_values(given_df: Union[pl.DataFrame, pl.LazyFrame]):
     ],
 )
 def test_has_mandatory_values_should_error_on_missing_elements(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     with pytest.raises(plg.PolarsAssertError):
         given_df.pipe(plg.has_mandatory_values, {"a": [3]})
@@ -50,7 +48,7 @@ def test_has_mandatory_values_should_give_feedback_on_missing_values():
     ],
 )
 def test_has_mandatory_values_should_accept_group_by_option(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     when = given_df.pipe(plg.has_mandatory_values, {"a": [1]}, group_by="group")
     testing.assert_frame_equal(given_df, when)
@@ -64,7 +62,7 @@ def test_has_mandatory_values_should_accept_group_by_option(
     ],
 )
 def test_has_mandatory_values_by_group_should_error_when_not_all_values_are_present(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     with pytest.raises(plg.PolarsAssertError):
         given_df.pipe(plg.has_mandatory_values, {"a": [1, 2]}, group_by="group")

--- a/tests/checks/test_has_no_infs.py
+++ b/tests/checks/test_has_no_infs.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -11,7 +9,7 @@ import pelage as plg
     "given_df", [pl.DataFrame({"a": [1, 2]}), pl.LazyFrame({"a": [1, 2]})]
 )
 def test_has_no_infs_returns_df_when_all_values_defined(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     when = given_df.pipe(plg.has_no_infs)
     testing.assert_frame_equal(given_df, when)
@@ -25,7 +23,7 @@ def test_has_no_infs_returns_df_when_all_values_defined(
     ],
 )
 def test_has_no_infs_throws_error_on_inf_values(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     with pytest.raises(plg.PolarsAssertError) as err:
         given_df.pipe(plg.has_no_infs)

--- a/tests/checks/test_has_no_nulls.py
+++ b/tests/checks/test_has_no_nulls.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -11,7 +9,7 @@ import pelage as plg
     "given_df", [pl.DataFrame({"a": [1, 2]}), pl.LazyFrame({"a": [1, 2]})]
 )
 def test_has_no_nulls_returns_df_when_all_values_defined(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     when = given_df.pipe(plg.has_no_nulls)
     testing.assert_frame_equal(given_df, when)
@@ -32,7 +30,7 @@ def test_has_no_nulls_throws_error_on_null_values(frame):
     ],
 )
 def test_has_no_nulls_indicates_columns_with_nulls_in_error_message(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     expected = pl.DataFrame(
         {"column": ["a"], "null_count": [1]},

--- a/tests/checks/test_not_accepted_values.py
+++ b/tests/checks/test_not_accepted_values.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -27,7 +25,7 @@ def test_not_accepted_values_should_accept_pl_expr():
     ],
 )
 def test_not_accepted_values_should_error_on_forbidden_values(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     items = {"a": [1], "b": ["a", "c"]}
 

--- a/tests/checks/test_not_constant.py
+++ b/tests/checks/test_not_constant.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -17,7 +15,7 @@ def test_not_constant():
     "given_df", [pl.DataFrame({"b": [1, 1]}), pl.LazyFrame({"b": [1, 1]})]
 )
 def test_not_constant_throws_error_on_constant_columns(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     with pytest.raises(plg.PolarsAssertError):
         given_df.pipe(plg.not_constant, "b")

--- a/tests/checks/test_not_null_proportion.py
+++ b/tests/checks/test_not_null_proportion.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -15,7 +13,7 @@ import pelage as plg
     ],
 )
 def test_not_null_proportion_accept_proportion_range_or_single_input(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     when = given_df.pipe(plg.not_null_proportion, {"a": (0.1, 1.0)})
     testing.assert_frame_equal(given_df, when)
@@ -44,7 +42,7 @@ def test_not_null_proportion_accept_group_by_option():
     ],
 )
 def test_not_null_proportion_should_error_with_too_many_nulls_per_group(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     with pytest.raises(plg.PolarsAssertError):
         given_df.pipe(plg.not_null_proportion, {"a": 0.5}, group_by="group")
@@ -58,7 +56,7 @@ def test_not_null_proportion_should_error_with_too_many_nulls_per_group(
     ],
 )
 def test_not_null_proportion_errors_with_too_many_nulls(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     with pytest.raises(plg.PolarsAssertError) as err:
         given_df.pipe(plg.not_null_proportion, {"a": 0.9})

--- a/tests/checks/test_unique.py
+++ b/tests/checks/test_unique.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import polars as pl
 import pytest
 from polars import testing
@@ -11,7 +9,7 @@ import pelage as plg
     "given_df", [pl.DataFrame({"a": [1, 2]}), pl.LazyFrame({"a": [1, 2]})]
 )
 def test_unique_should_return_df_if_column_has_unique_values(
-    given_df: Union[pl.DataFrame, pl.LazyFrame],
+    given_df: pl.DataFrame | pl.LazyFrame,
 ):
     when = given_df.pipe(plg.unique, "a")
     testing.assert_frame_equal(given_df, when)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 env_list =
         clean,
-        python{3.9,3.10,3.11,3.12,3.13,3.14}-polars{0.20, 1.2, 1.6, latest},
+        python{3.10,3.11,3.12,3.13,3.14}-polars{1.2, 1.6, 1.10, latest},
         report
 
 minversion = 4.13.0
@@ -15,12 +15,13 @@ deps =
     pytest>=6
     coverage>=7
     polarslatest: polars >= 1.6
+    polars1.10: polars >= 1.10, <1.20
     polars1.6: polars >= 1.6, <1.7
     polars1.2: polars >= 1.2, <1.3
-    polars0.20: polars >= 0.20, <0.21
+
 depends =
-    python{3.9,3.10,3.11,3.12,3.13,3.14}-polars{0.20, 1.2, 1.6, latest}: clean
-    report: python{3.9,3.10,3.11,3.12,3.13,3.14}-polars{0.20, 1.2, 1.6, latest}
+    python{3.10,3.11,3.12,3.13,3.14}-polars{1.1, 1.2, 1.6, 1.10, latest}: clean
+    report: python{3.10,3.11,3.12,3.13,3.14}-polars{1.1, 1.2, 1.6, latest}
 
 
 commands =


### PR DESCRIPTION
- breaking_change: Remove support for python-3.9 and polars < 1.2.0 
- breaking_change: Remove code specific to polars <1.1.0 
- chores(ruff): update type-hints to match min version py-3.10
- docs(griffe): pin griffe version to avoid incompatibilities from 2.0.0 
- docs(renderer): trim down extra parts that are specific for shiny 